### PR TITLE
feat: added support for M1 and all ARM based platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 
 set(POSTAL_CONFIG_OPTS )
 
+set(IS_SSE_DISABLED )
 # SSE / SSE2 isn't available on all platforms; arm, arm64 and arm/M1 (aarch64) are such examples
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
   set(IS_SSE_DISABLED --disable-sse2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if(NOT POSTAL_DATA_DIR)
   set(POSTAL_DATA_DIR /var/lib)
 endif()
 
+set(POSTAL_CONFIG_OPTS )
+
 # SSE / SSE2 isn't available on all platforms; arm, arm64 and arm/M1 (aarch64) are such examples
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
   set(IS_SSE_DISABLED --disable-sse2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,10 @@ if(NOT POSTAL_DATA_DIR)
   set(POSTAL_DATA_DIR /var/lib)
 endif()
 
-set(POSTAL_CONFIG_OPTS )
+# SSE / SSE2 isn't available on all platforms; arm, arm64 and arm/M1 (aarch64) are such examples
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+  set(IS_SSE_DISABLED --disable-sse2)
+endif()
 
 include(ExternalProject)
 
@@ -47,7 +50,7 @@ ExternalProject_Add(libpostal
   GIT_REPOSITORY    https://github.com/openvenues/libpostal
   GIT_TAG           9c975972
   PATCH_COMMAND     <SOURCE_DIR>/bootstrap.sh
-  CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-data-download --with-pic --datadir=${POSTAL_DATA_DIR}
+  CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ${IS_SSE_DISABLED} --disable-data-download --with-pic --datadir=${POSTAL_DATA_DIR}
   BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libpostal.a
 )
 


### PR DESCRIPTION
Current behavior on M1 and all ARM based platforms:
<img width="779" alt="Bildschirmfoto 2022-05-21 um 20 18 21" src="https://user-images.githubusercontent.com/454817/169664397-f47e28bc-cdd1-45c9-a2de-4d564c891956.png">

This is, because the SSE instruction set is `x86` / `x86_64` CPU architecture specific.

This PR conditionally disables SSE for those platforms and leads to a successful build:
<img width="1019" alt="Bildschirmfoto 2022-05-21 um 20 17 08" src="https://user-images.githubusercontent.com/454817/169664437-d0a03f75-d311-4fdb-8ddf-8eb3ba67997d.png">

The code to check for the platform has been taken from an Apple official build script:
https://opensource.apple.com/source/apache_mod_php/apache_mod_php-147/libpng/libpng/CMakeLists.txt